### PR TITLE
Add DeleteFunc & DeleteAll 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ PRs/issues for go-cache and what was and wasn't included; in short:
 - Add `GetStale()` to get items even after they've expired.
 - Add `Pop()` to get an item and delete it.
 - Add `Modify()` to atomically modify existing cache entries (e.g. lists, maps).
+- Add `DeleteAll()` to remove all items from the cache with onEvicted call.
+- Add `DeleteFunc()` to remove specific items from the cache atomically.
 - Various small internal and documentation improvements.
 
 NOTE: there is no "v1" release yet, and the API or semantics may still change


### PR DESCRIPTION
I added my version of `Flush` method and a new method called `FlushWithFilter`. This is not a serious PR, I just thought you may be interested in the differences in my version.

The differences between our `Flush` methods are:
**1.** in my version, `Flush` returns flushed `map[string]Item`
**2.** and calls `onEvicted` on flushed items. 

`FlushWithFilter` flushes filtered items and returns them. It may not be fast in caches with big size since it iterates over every item in the cache but it's up to the user to use it. 

