### PR TITLE
add (Get|Touch)OrAdd(WithExpire)? methods

### DIFF
--- a/zcache.go
+++ b/zcache.go
@@ -128,6 +128,15 @@ func (c *cache[K, V]) Add(k K, v V) error { return c.AddWithExpire(k, v, Default
 // It will return an error if the cache key doesn't exist.
 func (c *cache[K, V]) Replace(k K, v V) error { return c.ReplaceWithExpire(k, v, DefaultExpiration) }
 
+// GetOrAdd gets an item from the cache, or adds it with the default expiration
+// if it doesn't exist and returns the value.
+func (c *cache[K, V]) GetOrAdd(k K, v V) V { return c.GetOrAddWithExpire(k, v, DefaultExpiration) }
+
+// TouchOrAdd replaces the expiry of a key with the default expiration and
+// returns the current value, or adds it with the default expiration and returns
+// the value.
+func (c *cache[K, V]) TouchOrAdd(k K, v V) V { return c.TouchOrAddWithExpire(k, v, DefaultExpiration) }
+
 // SetWithExpire sets a cache item, replacing any existing item.
 //
 // If the duration is 0 (DefaultExpiration), the cache's default expiration time
@@ -206,6 +215,54 @@ func (c *cache[K, V]) ReplaceWithExpire(k K, v V, d time.Duration) error {
 	}
 	c.set(k, v, d)
 	return nil
+}
+
+// GetOrAddWithExpire returns an value from the cache if it exists. If it
+// doesn't exist, the given value is added and returned.
+//
+// If the duration is 0 (DefaultExpiration), the cache's default expiration time
+// is used. If it is -1 (NoExpiration), the item never expires.
+func (c *cache[K, V]) GetOrAddWithExpire(k K, v V, d time.Duration) V {
+	if d == DefaultExpiration {
+		d = c.defaultExpiration
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// "Inlining" of Get and Expired
+	item, ok := c.items[k]
+	if !ok || (item.Expiration > 0 && time.Now().UnixNano() > item.Expiration) {
+		item = c.set(k, v, d)
+	}
+	return item.Object
+}
+
+// TouchOrAdd replaces the expiry of a key with the given expiration and returns
+// the current value, or adds it with the given expiration and returns the
+// value.
+//
+// If the duration is 0 (DefaultExpiration), the cache's default expiration time
+// is used. If it is -1 (NoExpiration), the item never expires.
+func (c *cache[K, V]) TouchOrAddWithExpire(k K, v V, d time.Duration) V {
+	if d == DefaultExpiration {
+		d = c.defaultExpiration
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// "Inlining" of Get and Expired
+	item, ok := c.items[k]
+	if !ok || (item.Expiration > 0 && time.Now().UnixNano() > item.Expiration) {
+		return c.set(k, v, d).Object
+	}
+
+	if d > 0 {
+		item.Expiration = time.Now().Add(d).UnixNano()
+	}
+	c.items[k] = item
+	return item.Object
 }
 
 // Get an item from the cache.
@@ -561,7 +618,7 @@ func (c *cache[K, V]) DeleteFunc(filter func(key K, item Item[V]) (del, stop boo
 	return m
 }
 
-func (c *cache[K, V]) set(k K, v V, d time.Duration) {
+func (c *cache[K, V]) set(k K, v V, d time.Duration) Item[V] {
 	var e int64
 	if d == DefaultExpiration {
 		d = c.defaultExpiration
@@ -569,10 +626,12 @@ func (c *cache[K, V]) set(k K, v V, d time.Duration) {
 	if d > 0 {
 		e = time.Now().Add(d).UnixNano()
 	}
-	c.items[k] = Item[V]{
+	item := Item[V]{
 		Object:     v,
 		Expiration: e,
 	}
+	c.items[k] = item
+	return item
 }
 
 func (c *cache[K, V]) get(k K) (V, bool) {

--- a/zcache_test.go
+++ b/zcache_test.go
@@ -743,3 +743,47 @@ func TestRename(t *testing.T) {
 		t.Errorf(`Get("foo"): v=%v; ok=%v`, v, ok)
 	}
 }
+
+func TestGetOrAdd(t *testing.T) {
+	c := New[string, int](NoExpiration, 0)
+	v := c.GetOrAdd("a", 1)
+	if v != 1 {
+		t.Errorf("GetOrAdd did not return the added value: v=%v", v)
+	}
+	if v2 := c.GetOrAdd("a", 2); v2 != v {
+		t.Errorf("GetOrAdd did not return the existing value: v=%v; v2=%v", v, v2)
+	}
+	if _, exp, _ := c.GetWithExpire("a"); !exp.Equal(time.Time{}) {
+		t.Errorf("GetOrAdd did not add the default no expiration: exp=%v", exp)
+	}
+	if v2 := c.GetOrAddWithExpire("b", 2, time.Second); v2 != 2 {
+		t.Errorf("GetOrAddWithExpire did not return the added value: v2=%v", v2)
+	}
+	_, expiration, _ := c.GetWithExpire("b")
+	time.Sleep(time.Nanosecond)
+	if expiration.After(time.Now().Add(time.Second)) {
+		t.Errorf("GetOrAddWithExpire did not add the non-default expiration: expiration:%v", expiration)
+	}
+}
+
+func TestTouchOrAdd(t *testing.T) {
+	c := New[string, int](NoExpiration, 0)
+	v := c.TouchOrAdd("a", 1)
+	if v != 1 {
+		t.Errorf("TouchOrAdd did not return the added value: v=%v", v)
+	}
+	if v2 := c.TouchOrAdd("a", 2); v2 != v {
+		t.Errorf("TouchOrAdd did not return the existing value: v=%v; v2=%v", v, v2)
+	}
+	if _, exp, _ := c.GetWithExpire("a"); !exp.Equal(time.Time{}) {
+		t.Errorf("TouchOrAdd did not add the default no expiration: exp=%v", exp)
+	}
+	if v2 := c.TouchOrAddWithExpire("a", 2, time.Second); v2 != v {
+		t.Errorf("TouchOrAddWithExpire did not return the existing value: v=%v; v2=%v", v, v2)
+	}
+	_, expiration, _ := c.GetWithExpire("a")
+	time.Sleep(time.Nanosecond)
+	if expiration.After(time.Now().Add(time.Second)) {
+		t.Errorf("TouchOrAddWithExpire did not set the expiration: expiration:%v", expiration)
+	}
+}


### PR DESCRIPTION
This adds the following methods to `Cache[K,V]`:

```
GetOrAdd(K, V) V
GetOrAddWithExpire(K, V, time.Duration) V
TouchOrAdd(K, V)
TouchOrAddWithExpire(K, V, time.Duration) V
```

the helper function `c.set` is updated to return the Item that was set in order to help in the writing the Add case of these new methods.

Closes #8