### PR TITLE
Implement LimitCountSoft() and LimitCountHard()

### DIFF
--- a/zcache.go
+++ b/zcache.go
@@ -40,6 +40,14 @@ type (
 		mu                sync.RWMutex
 		onEvicted         func(K, V)
 		janitor           *janitor[K, V]
+
+		softLimit  int
+		softLast   time.Time
+		softAtMost time.Duration
+		softEager  int64
+
+		hardLimit int
+		onHard    func(K, V, time.Time)
 	}
 
 	// Item stored in the cache; it holds the value and the expiration time as
@@ -152,6 +160,7 @@ func (c *cache[K, V]) SetWithExpire(k K, v V, d time.Duration) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.checklimit()
 	c.items[k] = Item[V]{
 		Object:     v,
 		Expiration: e,
@@ -467,15 +476,76 @@ func (c *cache[K, V]) Pop(k K) (V, bool) {
 	return item.Object, true
 }
 
+// LimitCountHard sets the hard limit on the number of cache items.
+//
+// It will delete a random key if the hard limit is reached; ideally this should
+// never or rarely be invoked, and is only intended to avoid inordinate memory
+// usage with a runaway cache. It will call the onHard callback (which may be
+// nil) with the evicted key and its expiry. This is called in addition to the
+// regular OnEvicted() callback.
+//
+// The limit can be set to <=0 to disable it, which is the default.
+func (c *cache[K, V]) LimitCountHard(limit int, onHard func(K, V, time.Time)) {
+	// TODO(v3): ideally c.OnEvicted() should accept func(k K, v V, forced bool),
+	// or something along those lines. But we can't change that now, so it has
+	// an additional callback here.
+	c.hardLimit, c.onHard = limit, onHard
+}
+
+// LimitCountSoft sets the soft limit on the number of cache items.
+//
+// This will call the janitor to delete all expired keys (if any) when the
+// number of items is greater than the soft limit. This will only happen once
+// every softAtMost. If softEager is >0, this time is subtracted from the expiry
+// time to more eagerly delete keys. This does not guarantee the cache size
+// remains within the soft limit.
+//
+// The limit can be set to <=0 to disable it, which is the default.
+//
+// For example, to create a cache that cleans expired items once a day, but runs
+// it once an hour (at most) once there are 10,000 items:
+//
+//	c := zcache.New[string, string](zcache.NoExpiration, time.Hour*24)
+//	c.LimitCountSoft(10_000, time.Hour, 0)
+func (c *cache[K, V]) LimitCountSoft(limit int, softAtMost, softEager time.Duration) {
+	c.softLimit = limit
+	c.softAtMost = softAtMost
+	c.softEager = softEager.Nanoseconds()
+}
+
+// Should be called *before* setting the key, so the key currently set doesn't
+// get randomly evicted.
+func (c *cache[K, V]) checklimit() {
+	if c.softLimit > 0 && len(c.items) >= c.softLimit && time.Since(c.softLast) > c.softAtMost {
+		c.softLast = time.Now()
+		go c.deleteExpired(c.softEager)
+	}
+
+	if c.hardLimit > 0 && len(c.items) >= c.hardLimit {
+		for k, v := range c.items {
+			c.delete(k)
+			if c.onEvicted != nil {
+				c.onEvicted(k, v.Object)
+			}
+			if c.onHard != nil {
+				c.onHard(k, v.Object, time.Unix(0, v.Expiration))
+			}
+			break
+		}
+	}
+}
+
 // DeleteExpired deletes all expired items from the cache.
-func (c *cache[K, V]) DeleteExpired() {
+func (c *cache[K, V]) DeleteExpired() { c.deleteExpired(0) }
+
+func (c *cache[K, V]) deleteExpired(eager int64) {
 	var evictedItems []keyAndValue[K, V]
 	now := time.Now().UnixNano()
 	c.mu.Lock()
 
 	for k, v := range c.items {
 		// "Inlining" of expired
-		if v.Expiration > 0 && now > v.Expiration {
+		if v.Expiration > 0 && now+eager > v.Expiration {
 			ov, evicted := c.delete(k)
 			if evicted {
 				evictedItems = append(evictedItems, keyAndValue[K, V]{k, ov})
@@ -638,6 +708,7 @@ func (c *cache[K, V]) set(k K, v V, d time.Duration) Item[V] {
 		Object:     v,
 		Expiration: e,
 	}
+	c.checklimit()
 	c.items[k] = item
 	return item
 }

--- a/zcache_test.go
+++ b/zcache_test.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -967,5 +968,76 @@ func TestDeleteExpired(t *testing.T) {
 	slices.Sort(evicted)
 	if fmt.Sprintf("%v", evicted) != "[one three xxx zzz]" {
 		t.Errorf("%v", evicted)
+	}
+}
+
+func TestLimitHard(t *testing.T) {
+	for range 10 {
+		c := New[string, string](-1, time.Hour)
+		var onhard, onev atomic.Int32
+		c.LimitCountHard(3, func(k, v string, exp time.Time) { onhard.Add(1) })
+		c.OnEvicted(func(k, v string) { onev.Add(1) })
+
+		var wg sync.WaitGroup
+		wg.Add(5)
+		go func() { defer wg.Done(); c.Set("one", "a") }()
+		go func() { defer wg.Done(); c.Set("two", "b") }()
+		go func() { defer wg.Done(); c.Set("three", "c") }()
+		go func() { defer wg.Done(); c.Set("four", "d") }()
+		go func() { defer wg.Done(); c.Set("five", "e") }()
+		wg.Wait()
+		c.Set("six", "f")
+
+		if c.ItemCount() != 3 {
+			t.Error(c.ItemCount())
+		}
+		if k := c.Keys(); !slices.Contains(k, "six") {
+			t.Errorf("last key not present: %v", k)
+		}
+		if onhard.Load() != 3 {
+			t.Error(onhard.Load())
+		}
+		if onev.Load() != 3 {
+			t.Error(onev.Load())
+		}
+	}
+}
+
+func TestLimitSoft(t *testing.T) {
+	{
+		c := New[string, string](time.Nanosecond, -1)
+		c.LimitCountSoft(3, time.Hour, 0)
+
+		var wg sync.WaitGroup
+		wg.Add(5)
+		go func() { defer wg.Done(); c.Set("one", "a") }()
+		go func() { defer wg.Done(); c.Set("two", "b") }()
+		go func() { defer wg.Done(); c.Set("three", "c") }()
+		go func() { defer wg.Done(); c.Set("four", "d") }()
+		go func() { defer wg.Done(); c.Set("five", "e") }()
+		wg.Wait()
+		c.Set("six", "f")
+		time.Sleep(time.Nanosecond)
+		// No keys
+		// for _, k := range c.Keys() {
+		// 	fmt.Println(k)
+		// }
+	}
+
+	{
+		c := New[string, string](time.Hour, -1)
+		c.LimitCountSoft(3, time.Hour, time.Hour*2)
+
+		c.Set("one", "a")
+		c.Set("two", "b")
+		c.Set("three", "c")
+		c.Set("four", "d")
+		time.Sleep(time.Millisecond * 100) // Wait for delete to finish
+		c.Set("five", "e")
+		c.Set("six", "f")
+		// five and six, because atMost
+		// for _, k := range c.Keys() {
+		// 	fmt.Println(k)
+		// }
 	}
 }


### PR DESCRIPTION
This allows setting some basic limits on the cache size, mostly intended to prevent unbounded cache growth in some scenarios.

TODO: not entire happy with the names; I put the Count in there so there's space to add other limits in the future (e.g. LimitSizeSoft). Originally it was just LimitCount(soft, hard int), but then I added the options and it became too convoluted of a function signature.

TODO: write proper tests.

TODO: add Example() function

TODO: update FAQ in README

Ref: #12